### PR TITLE
Make Prometheus metrics configurable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,8 +68,10 @@ To build the frontend dependencies, you will need Node.js and yarn or npm.
 
 ## Web server configuration
 
-c3bottles can be used behind any WSGI compatible webserver. Some options and
-configuration examples are described here.
+c3bottles can be used behind any WSGI compatible web server. Some options and
+configuration examples are described here. If you encounter problems with
+modules not being found, please have a look in `wsgi.py` end uncomment the
+modifications to the module search path.
 
 ### Gunicorn
 
@@ -101,6 +103,13 @@ A sample uWSGI configuration file could look like this:
     chdir = /srv/c3bottles/
     wsgi-file = wsgi.py
     callable = c3bottles
+
+## Prometheus
+
+If you use Prometheus to collect service metrics, just uncomment
+`PROMETHEUS_ENABLED` in the configuration. This will start a Prometheus
+exporter together with the WSGI server. By defaults, metrics are available
+at [http://127.0.0.1:9567/](http://127.0.0.1:9567/).
 
 ## Map
 

--- a/c3bottles/lib/__init__.py
+++ b/c3bottles/lib/__init__.py
@@ -1,2 +1,0 @@
-from .statistics import stats_obj
-from .metrics import monitor

--- a/c3bottles/lib/metrics.py
+++ b/c3bottles/lib/metrics.py
@@ -3,7 +3,8 @@ from time import time
 
 from flask import request
 
-from . import stats_obj
+from .. import c3bottles
+from .statistics import stats_obj
 
 
 drop_point_count = Gauge(
@@ -44,7 +45,10 @@ def after_request(response):
     return response
 
 
-def monitor(app, addr="0.0.0.0", port=9567):
+def monitor(app,
+            address=c3bottles.config.get("PROMETHEUS_ADDRESS", "127.0.0.1"),
+            port=c3bottles.config.get("PROMETHEUS_PORT", 9567)):
     app.before_request(before_request)
     app.after_request(after_request)
-    start_http_server(port, addr)
+    start_http_server(port, address)
+    print("Prometheus exporter started on http://{}:{}/".format(address, port))

--- a/c3bottles/lib/statistics.py
+++ b/c3bottles/lib/statistics.py
@@ -8,22 +8,22 @@ class Statistics(object):
     @property
     def drop_point_count(self):
         try:
-            return DropPoint.query.filter(DropPoint.removed == None).count()
-        except:
+            return DropPoint.query.filter(DropPoint.removed == None).count()  # noqa
+        except:  # noqa
             return 0
 
     @property
     def report_count(self):
         try:
             return Report.query.count()
-        except:
+        except:  # noqa
             return 0
 
     @property
     def visit_count(self):
         try:
             return Visit.query.count()
-        except:
+        except:  # noqa
             return 0
 
     @property
@@ -36,7 +36,7 @@ class Statistics(object):
                 if not dp.removed:
                     s = dp.last_state
                     ret[s] = ret[s] + 1 if s in ret else 1
-        except:
+        except:  # noqa
             pass
         return ret
 
@@ -46,7 +46,7 @@ class Statistics(object):
         for state in Report.states:
             try:
                 ret[state] = Report.query.filter(Report.state == state).count()
-            except:
+            except:  # noqa
                 ret[state] = 0
         return ret
 
@@ -56,7 +56,7 @@ class Statistics(object):
         for action in Visit.actions:
             try:
                 ret[action] = Visit.query.filter(Visit.action == action).count()
-            except:
+            except:  # noqa
                 ret[action] = 0
         return ret
 

--- a/c3bottles/views/statistics.py
+++ b/c3bottles/views/statistics.py
@@ -1,9 +1,6 @@
 from flask import render_template, Blueprint, make_response
 
-from ..lib import stats_obj
-from ..model.drop_point import DropPoint
-from ..model.report import Report
-from ..model.visit import Visit
+from ..lib.statistics import stats_obj
 
 
 stats = Blueprint("statistics", __name__)

--- a/config.default.py
+++ b/config.default.py
@@ -13,6 +13,12 @@
 # The secret key used for signing the session cookie.
 # SECRET_KEY = "changeme"
 
+# Enable and configure the integrated Prometheus endpoint.
+# (default: False)
+# PROMETHEUS_ENABLED = True
+# PROMETHEUS_ADDRESS = "127.0.0.1"
+# PROMETHEUS_PORT = 9567
+
 # Mark the session and remember cookies as secure. You should enable this if
 # you run c3bottles on a HTTPS server.
 # SESSION_COOKIE_SECURE = True

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
 
-import sys
-import os
-
 # To be able to import modules in the project root directory, that directory
-# has to be added to the module search path (since e.g. Apache won't find the
-# modules otherwise).
-sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+# has to be added to the module search path if it is not the working directory.
+# This especially confuses Apache. If you are experiencing problems with modules
+# not being found, please uncomment the following lines:
+
+# import sys
+# import os
+# sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from c3bottles import c3bottles
-from c3bottles.lib import monitor
-
+from c3bottles.lib.metrics import monitor
 
 application = c3bottles
 
-monitor(c3bottles)
+if c3bottles.config.get("PROMETHEUS_ENABLED", False):
+    monitor(c3bottles)


### PR DESCRIPTION
The Prometheus listen address and port are now configurable. The settings
are available in config.default.py. By default, Prometheus is disabled.
If it is enabled, it will listen on 127.0.0.1 and port 9567 by default.

Prometheus will be enabled only if c3bottles is started using WSGI, not
in the development web server. INSTALL.md now has a few lines on Prometheus.

In addition, the module search path modifications in wsgi.py have been
commented out as they are only needed in ancient setups and the structure
for imports from lib has been made more concise with the rest.