### PR TITLE
Change Dockerfile to better cache build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN yarn build
 
 FROM python:3.6-alpine
 RUN apk add -U --no-cache \
-    nodejs py3-virtualenv cairo
+    py3-virtualenv cairo
 COPY --from=builder /usr/lib/libpq.so.5 /usr/lib/libpq.so.5
 COPY --from=builder /usr/lib/libldap_r-2.4.so.2 /usr/lib/libldap_r-2.4.so.2
 COPY --from=builder /usr/lib/liblber-2.4.so.2 /usr/lib/liblber-2.4.so.2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-source /c3bottles/venv/bin/activate
-exec "$@"


### PR DESCRIPTION
The Dockerfile now has different steps for installing the system dependencies,
installing the Python dependencies and installing the JavaScript dependencies.
Only after that, the actual frontend build takes place.

This allows for quick rebuilds of the image on code changes as we first copy
requirements.txt and package.json step by step, so the Python venv will only
be rebuilt when requirements.txt changes and the Node dependencies are only
installed again if either the Python venv changes (which is the most
time-consuming step of the build process anyway, so the JS stuff doesn't
really matter here) or package.json/yarn.lock change.

entrypoint.sh is not needed if we call Gunicorn directly from within the venv.