### PR TITLE
Improve venv handling in Docker and docs

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -12,7 +12,12 @@ box for a testing or development environment:
     to your setup (for the default docker-compose setup, you should use
     `SQLALCHEMY_DATABASE_URI = "postgresql://postgres:postgres@db/postgres"`).
 
-2.  Start the database using docker-compose:
+2.  By default, docker-compose will download the image from Docker Hub. If you
+    want to build your own image from source, please do:
+
+        docker build -t c3bottles/c3bottles .
+
+3.  Start the database using docker-compose:
 
         docker-compose up -d db
 
@@ -20,16 +25,20 @@ box for a testing or development environment:
 
         docker-compose up -d db adminer
 
-3.  Initialize the database:
+4.  Initialize the database:
 
-       docker-compose run --rm web /c3bottles/manage.py initdb
+        docker-compose run --rm web ./manage.py initdb
 
-4.  Create a user:
+5.  Create a user:
 
-        docker-compose run web /c3bottles/manage.py user create
+        docker-compose run --rm web ./manage.py user create
 
-5.  Start the web interface:
+6.  Start the web interface:
 
         docker-compose up -d web
 
     The web interface will listen on port 5000 by default.
+
+7.  If you are done with testing, simply stop and remove all the containers:
+
+        docker-compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ WORKDIR /c3bottles
 RUN apk add -U --no-cache \
     python3-dev nodejs yarn py3-pip py3-virtualenv libffi-dev gcc libc-dev zlib-dev jpeg-dev cairo postgresql-dev \
     && virtualenv -p python3 /c3bottles/venv
+ENV PATH=/c3bottles/venv/bin:$PATH
 COPY requirements.txt /c3bottles
-RUN /c3bottles/venv/bin/pip3 install -r requirements.txt --no-cache-dir
+RUN pip3 install -r requirements.txt --no-cache-dir
 COPY package.json yarn.lock /c3bottles/
 RUN yarn
 COPY . /c3bottles
@@ -20,6 +21,7 @@ COPY --from=builder /usr/lib/liblber-2.4.so.2 /usr/lib/liblber-2.4.so.2
 COPY --from=builder /usr/lib/libsasl2.so.3 /usr/lib/libsasl2.so.3
 COPY --from=builder /c3bottles /c3bottles
 WORKDIR /c3bottles
+ENV PATH=/c3bottles/venv/bin:$PATH
 EXPOSE 5000
 EXPOSE 9567
-CMD /c3bottles/venv/bin/gunicorn -b 0.0.0.0:5000 wsgi
+CMD gunicorn -b 0.0.0.0:5000 wsgi


### PR DESCRIPTION
Getting rid of the entry point made all commands long, because all the Python
binaries needed to be called from within the virtualenv explicitly. However,
there is a simple solution: Just prepend the venv/bin directory to the PATH
and everything works like from within the virtualenv (actually, this is
essentially what `source venv/bin/activate` would do).

All management commands and starting the server etc. will become easier now.

In addition, the Docker documentation now mentions building and stopping
everything (good for Docker noobs as me...).