### PR TITLE
Make the map configurable

### DIFF
--- a/c3bottles/config/map.py
+++ b/c3bottles/config/map.py
@@ -1,0 +1,31 @@
+class MapSource:
+    attribution_name = None
+    attribution_link = None
+    tile_server = None
+    bounds = None
+    min_zoom = 0
+    max_zoom = 7
+    initial_zoom = 0
+    level_config = None
+
+    @classmethod
+    def get_attribution(cls):
+        if cls.attribution_name is None:
+            return ""
+        if cls.attribution_link is not None:
+            return "Powered by <a href='{}'>{}</a>".format(
+                cls.attribution_link, cls.attribution_name
+            )
+        else:
+            return "Powered by {}".format(cls.attribution_name)
+
+
+class C3Nav35C3(MapSource):
+    attribution_name = "c3nav"
+    attribution_link = "https://c3nav.de/"
+    tile_server = "https://35c3.c3nav.de/map/"
+    min_zoom = 0
+    max_zoom = 5
+    initial_zoom = 0
+    bounds = [[0.0, 0.0], [800.0, 550.0]]
+    level_config = [[6, -1], [7, 0], [8, 1], [9, 2]]

--- a/c3bottles/config/map.py
+++ b/c3bottles/config/map.py
@@ -1,31 +1,31 @@
 class MapSource:
-    attribution_name = None
-    attribution_link = None
-    tile_server = None
-    bounds = None
-    min_zoom = 0
-    max_zoom = 7
-    initial_zoom = 0
-    level_config = None
-
     @classmethod
-    def get_attribution(cls):
-        if cls.attribution_name is None:
-            return ""
-        if cls.attribution_link is not None:
-            return "Powered by <a href='{}'>{}</a>".format(
-                cls.attribution_link, cls.attribution_name
-            )
-        else:
-            return "Powered by {}".format(cls.attribution_name)
+    def __getattr__(cls, _):
+        return None
 
 
 class C3Nav35C3(MapSource):
-    attribution_name = "c3nav"
-    attribution_link = "https://c3nav.de/"
+    attribution = "Powered by <a href='https://c3nav.de/'>c3nav</a>"
     tile_server = "https://35c3.c3nav.de/map/"
     min_zoom = 0
     max_zoom = 5
     initial_zoom = 0
     bounds = [[0.0, 0.0], [800.0, 550.0]]
     level_config = [[6, -1], [7, 0], [8, 1], [9, 2]]
+    simple_crs = True
+    hack_257px = True
+
+
+class OpenStreeMapCamp2019(MapSource):
+    attribution = \
+        "<a href='https://www.openstreetmap.org/copyright'>© OpenStreepMap Contributers</a>"
+    tile_server = "https://{s}.tile.openstreetmap.org/"
+    tile_server_subdomains = ["a", "b", "c"]
+    min_zoom = 17
+    max_zoom = 19
+    initial_zoom = 17
+    initial_view = {
+        "lat": 53.03124,
+        "lng": 13.30734,
+        "zoom": 17
+    }

--- a/config.default.py
+++ b/config.default.py
@@ -13,6 +13,11 @@
 # The secret key used for signing the session cookie.
 # SECRET_KEY = "changeme"
 
+# The map to use. The different maps are defined in c3bottles/config/map.py
+# and the setting here selects one of the different maps that are available.
+from c3bottles.config.map import *
+MAP_SOURCE = C3Nav35C3
+
 # The name of the drop point label template. This must be a SVG file placed in
 # the templates/label directory. The setting is the base name of this file,
 # i.e. without extension.

--- a/templates/js/base.js
+++ b/templates/js/base.js
@@ -1,15 +1,19 @@
 var apiurl = "{{ url_for('api.process') }}";
 var imgdir = "{{ url_for('static', filename='img') }}";
 
-{% set map_source = config.MAP_SOURCE %}
+{% set map_source = config.get("MAP_SOURCE") %}
 var map_source = {
-    attribution: "{{ map_source.get_attribution() }}",
+    attribution: "{{ map_source.attribution }}",
     tile_server: "{{ map_source.tile_server }}",
-    bounds: {{ map_source.bounds }},
-    level_config: {{ map_source.level_config }},
-    min_zoom: {{ map_source.min_zoom }},
-    max_zoom: {{ map_source.max_zoom }},
-    initial_zoom: {{ map_source.initial_zoom }},
+    tile_server_subdomains: {{ map_source.tile_server_subdomains if map_source.tile_server_subdomains else [] }},
+    bounds: {{ map_source.bounds if map_source.bounds else "undefined" }},
+    initial_view: {{ map_source.initial_view if map_source.initial_view else "undefined" }},
+    level_config: {{ map_source.level_config if map_source.level_config else "undefined" }},
+    min_zoom: {{ map_source.min_zoom if map_source.min_zoom else 0 }},
+    max_zoom: {{ map_source.max_zoom if map_source.max_zoom else 0 }},
+    initial_zoom: {{ map_source.initial_zoom if map_source.initial_zoom else 0}},
+    simple_crs: {{ map_source.simple_crs|lower if map_source.simple_crs else "false" }},
+    hack_257px: {{ map_source.hack_257px|lower if map_source.hack_257px else "false" }}
 };
 
 var drop_points = {{ all_dps_json|safe }};

--- a/templates/js/base.js
+++ b/templates/js/base.js
@@ -1,6 +1,17 @@
 var apiurl = "{{ url_for('api.process') }}";
 var imgdir = "{{ url_for('static', filename='img') }}";
 
+{% set map_source = config.MAP_SOURCE %}
+var map_source = {
+    attribution: "{{ map_source.get_attribution() }}",
+    tile_server: "{{ map_source.tile_server }}",
+    bounds: {{ map_source.bounds }},
+    level_config: {{ map_source.level_config }},
+    min_zoom: {{ map_source.min_zoom }},
+    max_zoom: {{ map_source.max_zoom }},
+    initial_zoom: {{ map_source.initial_zoom }},
+};
+
 var drop_points = {{ all_dps_json|safe }};
 
 init_drop_point_refreshing();


### PR DESCRIPTION
This still has a few issues, e.g. it will show everything as "on level 0" when using OpenStreepMap, but switching back and forth between `C3Nav35C3` and `OpenStreepMapCamp2019` in `config.py` works and both maps seem to work reasonably well.

`LevelControl` in `js/map.js` has been renamed to `LayerControl`. The reasoning behind this is to draw a clear line between *map layers* (in case of c3nav 6, 7, 8, 9) and *building levels* (in that case -1, 0, 1, 2). The former are relevant for tileserver URLs while the latter are the real-world building level numbers that we have in our database. The bridge between these two worlds is the `level_config` property of each map configuration. This has a double roIe at the moment: If it is falsy, this implies that the map has only a single layer.

The JavaScript code has been thrown together quickly from older stuff. It is ugly and only optimized so that eslint won't complain when building. This probably needs a thorough cleanup.

Python issues:

- [ ] improve the map configuration and make it more concise (this is still somewhat handwavy at the moment)
- [ ] provide some fallback if the map is not configured (map view should be disabled but drop point creation without positional information should be possible)
- [ ] add documentation for the map parameters (especially the simple CRS and the 257 px tile hack for c3nav)
- [ ] remove all references to levels in the frontend if the map chosen does not have a level config set

Other stuff still missing:

- [ ] bring back the gdal2tiles script and other stuff needed to render our own tiles from monster PNGs (like used on 32C3) and add an appropriate map configuration