### PR TITLE
Fix sorting for listview of droppoints

### DIFF
--- a/js/common/list.js
+++ b/js/common/list.js
@@ -78,7 +78,7 @@ module.exports.initializeTable = function () {
       data: null,
       render(data, type) {
         if (type === 'sort') {
-          return labels[data.last_state].num;
+          return states[data.last_state].num;
         }
 
         return $('<span/>')


### PR DESCRIPTION
There was a wrong reference to a variable no longer being created. I used the variable being used elsewhere and using chrome overwrites to use this file instead of the original it works as expected.