### PR TITLE
docs: add missing pnpm install

### DIFF
--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -10,7 +10,7 @@ prepare your development environment is as follows:
     git clone https://github.com/c3bottles/c3bottles.git
     cd c3bottles
     make venv
-    pnpm
+    pnpm install
     pnpm build
 
 If you want to work on the Python code, a pnpm task is available that starts

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -36,7 +36,7 @@ To build the frontend dependencies, you will need Node.js and pnpm (corepack).
 
 3.  Fetch the frontend dependencies and build everything:
 
-        pnpm
+        pnpm install
         pnpm build
 
 4.  Create a configuriation file `config.py`. You will find a template for


### PR DESCRIPTION
When just running pnpm build as documented, it complains that `run-s` is not present and recommends in a warning message to run pnpm install.