### PR TITLE
use preferred tile.openstreetmap.org URL

### DIFF
--- a/c3bottles/config/map.py
+++ b/c3bottles/config/map.py
@@ -71,8 +71,7 @@ class OpenStreetMapCamp2019(MapSource):
     attribution = (
         "<a href='https://www.openstreetmap.org/copyright'>© OpenStreepMap contributers</a>"
     )
-    tileserver = "https://{s}.tile.openstreetmap.org/"
-    tileserver_subdomains = ["a", "b", "c"]
+    tileserver = "https://tile.openstreetmap.org/"
     min_zoom = 16
     max_zoom = 19
     initial_view = {"lat": 53.03124, "lng": 13.30734, "zoom": 17}

--- a/doc/MAP.md
+++ b/doc/MAP.md
@@ -31,8 +31,7 @@ c3bottles ships with a number of map sources that can be used directly:
     The *OpenStreetMapCamp2019* configuration is an example for OpenStreetMap
     and pointing at the location of the Chaos Communication Camp 2019 in
     Mildenberg. The starting location and zoom levels can be easily adapted
-    as needed. OpenStreepMap only has one layer. The `tileserver_subdomains`
-    option is used to distribute load over different tile servers.
+    as needed. OpenStreepMap only has one layer.
 
 *   **c3nav**: c3nav is a routing webservice for chaos events that is available
     for use at [https://c3nav.de/](https://c3nav.de/) and being developed at


### PR DESCRIPTION
Tile subdomains for OpenStreetMap are no longer necessary and should no longer be used. Even though this code is for an old event, it may serve as an example in the future and should thus be updated.

see https://github.com/openstreetmap/operations/issues/737