### PR TITLE
fix language picker url

### DIFF
--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -33,7 +33,7 @@
                     </a>
                     <div class="dropdown-menu">
                         {% for l in g.languages %}
-                        <a class="dropdown-item" href="{{ request.path }}?lang={{ l }}">{{ g.locales[l].get_display_name() }}</a>
+                        <a class="dropdown-item" href="{{ url_for(request.endpoint, lang=l, **(request.view_args or {})) }}">{{ g.locales[l].get_display_name() }}</a>
                         {% endfor %}
                     </div>
                 </li>


### PR DESCRIPTION
If the installation is mounted in a subdirectory of a reverse proxy (e.g. using gunicorn with `SCRIPT_NAME`), the language picker will generate an incorrect URL.

To be specific, Flask does not put the configured URL prefix inside of `Request.path`, instead the prefix only is in `Request.root_path`:

> ### [`root_path`](https://flask.palletsprojects.com/en/stable/api/#flask.Request.root_path)
> The prefix that the application is mounted under, without a trailing slash. [`path`](https://flask.palletsprojects.com/en/stable/api/#flask.Request.path) comes after this.

To avoid having to take care of all these possible shenanigans, use `url_for` instead, passing the current endpoint and its current arguments. The current query arguments are not passed, as the previous code did not deal with that either and it would be relatively complicated to do so.