### PR TITLE
Add build and publish workflow for docker image

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,0 +1,51 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v5
 
-      - name: Log in to Docker Hub
+      - name: Log in to the Container registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: ${{ env.REGISTRY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ FROM base
 COPY --from=fontloader /usr/share/fonts/ /usr/share/fonts/
 COPY --from=builder /c3bottles /c3bottles
 RUN fc-cache -f
+RUN chown -R c3bottles /c3bottles
 USER c3bottles
 WORKDIR /c3bottles
 VOLUME /c3bottles/static


### PR DESCRIPTION
Hey,

thanks for developing this great project — we’re planning to use the c3bottles system at a small event in Aalen.

We deploy our services using Kubernetes, so it was nice to see that this repository already includes a Dockerfile. It would be even more convenient if the image were built and published upstream, so we could pull it directly without having to build it ourselves.

Let me know what you think!

Best,
LucAA